### PR TITLE
merge systick

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -147,6 +147,7 @@ func (b *button) RecognizeAndPublish(tickerCh chan struct{}) {
 		select {
 		case <-tickerCh:
 			if ticks == 0 { // we aren't listening
+				btnDown = time.Time{} // ensure this is empty because occasionally it isn't
 				continue
 			} else {
 				ticks += 1


### PR DESCRIPTION
- `(Bouncer).HandlePin` is the button's pin interrupt handler
  - fires on `PinRising` & `PinFalling` events
  - it sends a `Bounce` (containing the current time & pin state) to the Bouncer's `isrChan` channel, which is consumed by `(Bouncer).RecognizeAndPublish`
- Consumes `SysTick_Handler` for debouncing & requires some setup on your part
  - outside of this package, you must set up a systick handler set to an interval of your desired debounce duration. This function should send empty structs to a buffered channel (capacity of 1) which will be then passed to `(Bouncer).RecognizeAndPublish`
  - `SysTick_Handler` is attached to a func using the Go macro `//go:export SysTick_Handler` as a comment above the function definition
  - consumes the (only?) SysTick_Handler on the MCU and may not even be available on all MCUs
  - In order to use multiple buttons as Bouncers with the same systick handler, you need to use a second function which reads the systick's output channel and sends empty structs on multiple channels -- one for each of your buttons/Bouncers
  - pass this channel, either directly from the SysTick_Handler or through your relay, to `(Bouncer).RecognizeAndPublish`
- `(Bouncer).RecognizeAndPublish` is the button-press-length recognizer & publisher 
  - Each Bouncer has durations for `ShortPress`, `LongPress`, and `ExtraLongPress` (these are hard coded, probably need to create a `Config` struct they can be set up with)
  - Each button can have multiple subscribers via output channels where button press events - as a `PressLength` - are published
- Support for `eyelight/statist` interface methods `Name()` and `StateString()`