### PR TITLE
Reduce heap

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -50,6 +50,7 @@ type bouncer struct {
 type Bouncer interface {
 	Configure(Config) error
 	RecognizeAndPublish()
+	State() bool
 	Duration(PressLength) time.Duration
 }
 
@@ -94,6 +95,11 @@ func (b *bouncer) Configure(cfg Config) error {
 	}
 	addSysTickConsumer(b.tickerCh)
 	return nil
+}
+
+// State returns an on-demand measurement of the bouncer's pin
+func (b *bouncer) State() bool {
+	return b.pin.Get()
 }
 
 // RecognizeAndPublish should be a goroutine; reads pin state & sample time from channel,

--- a/example/main.go
+++ b/example/main.go
@@ -9,9 +9,9 @@ import (
 )
 
 var (
-	sysTicks = make(chan struct{}, 1)
-	outChan1 = make(chan bouncer.PressLength, 1)
-	outChan2 = make(chan bouncer.PressLength, 1)
+	sysTicks  = make(chan struct{}, 1)
+	aliceChan = make(chan bouncer.PressLength, 1)
+	bobChan   = make(chan bouncer.PressLength, 1)
 )
 
 func launchSystick() {
@@ -31,7 +31,7 @@ func handleSystick() {
 
 func main() {
 	launchSystick()
-	btn, err := bouncer.New(machine.D3, outChan1, outChan2)
+	btn, err := bouncer.New(machine.D3, aliceChan, bobChan)
 	if err != nil {
 		println("couldn't make new bouncer")
 	}
@@ -45,9 +45,9 @@ func main() {
 	}
 
 	go btn.RecognizeAndPublish()
-	go reactToPresses("Alice", outChan1)
-	go reactToPresses("Bob", outChan2)
-	go bouncer.Relay(sysTicks)
+	go reactToPresses("Alice", aliceChan)
+	go reactToPresses("Bob", bobChan)
+	go bouncer.Debounce(sysTicks)
 	select {}
 }
 
@@ -62,7 +62,7 @@ func reactToPresses(name string, ch chan bouncer.PressLength) {
 				println(name + " got a long press")
 			case bouncer.ExtraLongPress:
 				println(name + " got an extra long press")
-			case bouncer.Debounce:
+			case bouncer.Bounce:
 				println(name + " got a bounce")
 			}
 		}


### PR DESCRIPTION
- removed the `Bounce` struct
- remove heap allocations in the interrupt handler, passing only the button state
- set bounce event time at the earliest appropriate time rather than in the interrupt
-  add method `State()` to the Bouncer interface which returns the current state of a button (useful for button combinations)
- changed `Relay()` to `Debounce()`
- clean up the example & the readme to reflect the new