### PR TITLE
Don't block in ISR function; avoid hanging

### DIFF
--- a/bouncer.go
+++ b/bouncer.go
@@ -163,9 +163,10 @@ func (b *bouncer) Duration(l PressLength) time.Duration {
 // publish concurrently sends a PressLength to all channels subscribed to this Bouncer
 func (b *bouncer) publish(p PressLength) {
 	for i := range b.outChans {
-		go func(i int) {
-			b.outChans[i] <- p
-		}(i)
+		select {
+		case b.outChans[i] <- p:
+		default:
+		}
 	}
 }
 


### PR DESCRIPTION
While using this library for a project I noticed I would get random hangs/crashes when pressing input buttons.  After some investigation I realized the ISR registered by the bouncer library could block if `isrChan` was not empty.  This is a race condition that causes the ISR to never return, which hangs the program.  I don't have a chip debugger to prove it, but I believe the ISR is the source of the hang.

Changes:
- I added a select with a default clause on `isrChan` publish per TinyGo best practices:  https://tinygo.org/docs/concepts/compiler-internals/interrupts/
- I expanded the `isrChan` capacity to reduce the chances of an interrupt getting lost.

In local manual testing on a Raspberry Pi Pico (mashing buttons) I could reliably hang the program with the original code but got zero hangs with the bug fix.  I will mark the PR as ready for review next week after some additional bench time with the changes.

Based on this new code there is a small chance of the interrupt getting lost when triggered very rapidly.  IMO that is better than a hang, and the button state will recover on subsequent button presses.  The main loop could be rewritten to account for this scenario, but that is outside the scope of this PR.  LMK if you want me to investigate that further.